### PR TITLE
outdated domain name manta.life

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -176,7 +176,7 @@
 - [Neocities](https://neocities.org/)
 
 ## :page_facing_up: Invoice
-- [Manta](https://manta.life/)
+- [Manta](https://getmanta.app/)
 - [Billdogg](https://billdogg.com/)
 
 ## License


### PR DESCRIPTION
manta.life redirect to https://dan.com/fr-fr/buy-domain/manta.life?redirected=true&tld=life